### PR TITLE
sensors: bst: Do not include buildversion.mk

### DIFF
--- a/sensors/bst/daemon/Android.mk
+++ b/sensors/bst/daemon/Android.mk
@@ -73,7 +73,7 @@ endif
 include $(LOCAL_PATH)/../tools/l8150_config.mk
 
 include $(LOCAL_PATH)/../tools/options.mk
-include $(LOCAL_PATH)/../tools/buildversion.mk
+
 
 ifeq (true, $(flip_gesture_support))
 LOCAL_SRC_FILES += src/channel_gest_flip.c

--- a/sensors/bst/hal/Android.mk
+++ b/sensors/bst/hal/Android.mk
@@ -60,7 +60,7 @@ LOCAL_PRELINK_MODULE := false
 include $(LOCAL_PATH)/../tools/l8150_config.mk
 
 include $(LOCAL_PATH)/../tools/options.mk
-include $(LOCAL_PATH)/../tools/buildversion.mk
+
 
 ifeq (true, $(bmp_support))
 LOCAL_SRC_FILES += BstSensorPressure.cpp


### PR DESCRIPTION
We don't need to regenerate version folder every build. it cause jenkins erors.